### PR TITLE
Update config when changing profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ A tool for managing AWS default account, rvm-style.
 Usage:
 
 * `avm --add -f ~/Downloads/another_random_AWS_keypair.csv -a alias_that_makes_sense` to pull a profile into ~/.aws/credentials
-* `avm --use your-profile-name` to set a profile as default
-* `avm` to choose default profile from the list:
+* `avm --use your-profile-name` to set a profile as default in ~/.aws/credentials and ~/.aws/config, if present
+* `avm` to choose default profile from a list of profiles in ~/.aws/credentials and ~/.aws/config:
 
 ![list](list.png)
 

--- a/avm/bin/avm
+++ b/avm/bin/avm
@@ -5,28 +5,38 @@ import configparser
 from csv import DictReader
 from os.path import expanduser, isfile
 
-config = configparser.ConfigParser()
 home = expanduser('~')
-home_creds = home + '/.aws/credentials'
-config.read(home_creds)
+
+home_credentials = home + '/.aws/credentials'
+credentials = configparser.ConfigParser()
+credentials.read(home_credentials)
+
+home_config = home + '/.aws/config'
+config = configparser.ConfigParser()
+config.read(home_config)
 
 profiles = [
     inquirer.List(
         'profile',
         message="Select a profile to set as default",
-        choices=config.sections(),
+        choices=list(set(credentials.sections() + config.sections())),
     ),
 ]
 
 
 def magic(new_profile_name):
-    if new_profile_name in config:
-        new_profile_name_default = config[str(new_profile_name)]
-        config['default'] = new_profile_name_default
-        with open(home_creds, 'w') as configfile:
-            config.write(configfile)
-        print(f'AWS profile `{new_profile_name}` has been set as default')
-    else:
+    found_flag = False
+    for parser, file_path in zip([credentials, config],
+                                 [home_credentials, home_config]):
+        if new_profile_name in parser:
+            found_flag = True
+            new_profile_name_default = parser[str(new_profile_name)]
+            parser['default'] = new_profile_name_default
+            with open(file_path, 'w') as parser_file:
+                parser.write(parser_file)
+            print(f'AWS profile `{new_profile_name}` has been set as default in `{file_path}`')
+
+    if not found_flag:
         print(f'AWS profile `{new_profile_name}` not found')
         exit(1)
 
@@ -47,7 +57,7 @@ if args.add:
                     config.add_section(args.alias)
                     config[args.alias]["aws_access_key_id"] = row['Access key ID']
                     config[args.alias]["aws_secret_access_key"] = row['Secret access key']
-                    with open(home_creds, 'w') as configfile:
+                    with open(home_credentials, 'w') as configfile:
                         config.write(configfile)
     else:
         exit("No alias was provided")

--- a/avm/bin/avm
+++ b/avm/bin/avm
@@ -43,22 +43,22 @@ def magic(new_profile_name):
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--add", required=False, action='store_true')
-parser.add_argument("-f", "--credentials-file", required=False)
+parser.add_argument("-f", "--credentials-file", dest='new_creds', required=False)
 parser.add_argument("-a", "--alias", required=False)
 parser.add_argument("--use", required=False)
 args = parser.parse_args()
 
 if args.add:
     if args.alias:
-        if isfile(args.credentials_file):
-            with open(args.credentials_file, 'r') as credfile:
-                reader = csv.DictReader(credfile)
+        if isfile(args.new_creds):
+            with open(args.new_creds, 'r') as new_cred_handle:
+                reader = DictReader(new_cred_handle)
+                credentials.add_section(args.alias)
                 for row in reader:
-                    config.add_section(args.alias)
-                    config[args.alias]["aws_access_key_id"] = row['Access key ID']
-                    config[args.alias]["aws_secret_access_key"] = row['Secret access key']
-                    with open(home_credentials, 'w') as configfile:
-                        config.write(configfile)
+                    credentials[args.alias]["aws_access_key_id"] = row['Access key ID']
+                    credentials[args.alias]["aws_secret_access_key"] = row['Secret access key']
+            with open(home_credentials, 'w') as cred_handle:
+                credentials.write(cred_handle)
     else:
         exit("No alias was provided")
 elif args.use:

--- a/avm/bin/avm
+++ b/avm/bin/avm
@@ -18,6 +18,7 @@ profiles = [
     ),
 ]
 
+
 def magic(new_profile_name):
     if new_profile_name in config:
         new_profile_name_default = config[str(new_profile_name)]
@@ -31,10 +32,10 @@ def magic(new_profile_name):
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--add",required=False, action='store_true')
-parser.add_argument("-f","--credentials-file",required=False)
-parser.add_argument("-a","--alias",required=False)
-parser.add_argument("--use",required=False)
+parser.add_argument("--add", required=False, action='store_true')
+parser.add_argument("-f", "--credentials-file", required=False)
+parser.add_argument("-a", "--alias", required=False)
+parser.add_argument("--use", required=False)
 args = parser.parse_args()
 
 if args.add:

--- a/avm/bin/avm
+++ b/avm/bin/avm
@@ -3,10 +3,7 @@ import argparse
 import inquirer
 import configparser
 from csv import DictReader
-from sys import argv
-from os import environ
 from os.path import expanduser, isfile
-import csv
 
 config = configparser.ConfigParser()
 home = expanduser('~')


### PR DESCRIPTION
AWS CLI pulls from both `credentials` and `config` files, with `credentials` being preferred (see the [docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where)). The changes in this PR will cause the default profile in both files to be updated.

This PR addresses issue #2 and includes minor refactoring. 